### PR TITLE
Enable a switch for optional internal scrolling or reporting button 8.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ This project uses an Arduino Leonardo (or compatible boards, like the CMCU Beetl
 The smallest boards can be integrated directly into the trackball, so that the TrackmanFX appears as a "native" USB device.
 
 One example of such a modification is [here](doc/README.md).
+
+The default mode of operation emulates the scroll wheel inside the microcontroller and needs no additional software setup. If you want the full experience of two-dimensional scrolling with the trackball when pressing the red button, you can pull pin 6 to ground and then configure button 8 for scrolling with xinput on X11, for example, just like with the native PS/2 connection.


### PR DESCRIPTION
This serves to configure two-dimensional scrolling via software wheel emulation just like when having the Trackball wired up directly to a PS/2 port. Since many people could be happy with the effortless vertical scrolling in hardware, the default stays as it is.

Switch pin 6 of the Arduino to ground to enable reporting of button 8 instead of scroll events. On a recent Linux box with Xorg issuing

	name='Arduino LLC Arduino Leonardo'
	xinput --set-prop "$name" 'libinput Scroll Method Enabled' 0 0 1
	xinput --set-prop "$name" 'libinput Button Scrolling Button' 8
	xinput set-button-map "$name" 1 2 3 4 5 6 7 0

Gives you the original experience (the last line avoiding spurious clicks from the scroll button).